### PR TITLE
basic parse of suffix for colon commands

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -104,14 +104,35 @@ static char *suffix (void)
   return string;
 }
 
+static char *skip_ws(char *buf)
+{
+  while (*buf == ' ')
+    buf++;
+  return buf;
+}
+
+static char *skip_prgm(char *buf)
+{
+  for (; *buf; buf++)
+    if (*buf == ' ')
+      {
+	*buf = '\0';		/* null terminate prgm */
+	buf++;
+	break;
+      }
+  return buf;
+}
+
 static void colon (void)
 {
   if (!nprefix)
     {
-      char *suff = suffix();
-      if (suff != NULL)
+      char *cmd = suffix();
+      if (cmd != NULL)
 	{
-	  fprintf (stderr, "\r\nColon command: %s\r\n", suff);
+	  cmd = skip_ws(cmd);
+	  char *arg = skip_ws(skip_prgm(cmd));
+	  fprintf (stderr, "\r\nColon command: %s arg: %s\r\n", cmd, arg);
 	  done = 1;
 	}
       else				/* user rubbed out : */

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -106,14 +106,21 @@ static char *suffix (void)
 
 static void colon (void)
 {
-  char *suff = suffix();
-  if (suff != NULL)
+  if (!nprefix)
     {
-      fprintf (stderr, "\r\nColon command: %s\r\n", suff);
-      done = 1;
+      char *suff = suffix();
+      if (suff != NULL)
+	{
+	  fprintf (stderr, "\r\nColon command: %s\r\n", suff);
+	  done = 1;
+	}
+      else				/* user rubbed out : */
+	fprintf (stderr, "\010 \010");
     }
-  else				/* user rubbed out : */
-    fprintf (stderr, "\010 \010");
+  else {
+    fprintf(stderr, "\r\nColon prefix: %s\r\n", prefix);
+    done = 1;
+  }
 }
 
 static void logout (void)

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -169,6 +169,7 @@ void dispatch_init (void)
   alt[RUBOUT] = rubout;
 
   plain[':'] = colon;
+  alt[':'] = colon;
   alt['u'] = login;
   alt['?'] = print_args;
 }


### PR DESCRIPTION
This initial parse of <prgm> only skips past non-space characters.
Multiple space processing.
No :$comment$ yet.
Factored to make it easier to expand later.
