### PR TITLE
System command detection in ccmd()

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,6 @@ clobber: clean
 	$(RM) $(PROGS)
 
 main.o: main.c term.h dispatch.h
-dispatch.o: dispatch.c term.h
+dispatch.o: dispatch.c term.h ccmd.h
 term.o: term.c
 ccmd.o: ccmd.c ccmd.h

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -1,8 +1,14 @@
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
+#include <fcntl.h>
 #include <sys/utsname.h>
 #include "ccmd.h"
+
+enum sysdir { SYS, SYS1, SYS2, SYS3 };
+#define QTY_SYSFDS 4
+int sysfds[QTY_SYSFDS];
 
 void help(char *);
 void version(char *);
@@ -38,6 +44,34 @@ static int builtin(char *name, char *arg)
 	return 1;
       }
   return 0;
+}
+
+void init_ccmd(void)
+{
+  sysfds[SYS] = openat(AT_FDCWD,
+		       "/bin", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  sysfds[SYS1] = openat(AT_FDCWD,
+			"/sbin", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  sysfds[SYS2] = openat(AT_FDCWD,
+			"/usr/bin", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  sysfds[SYS3] = openat(AT_FDCWD,
+			"/usr/sbin", O_PATH | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+}
+
+static int syscommand(char *name, char *arg)
+{
+  int fd;
+  for (int i = 0; i < QTY_SYSFDS; i++)
+    {
+      if (sysfds[i] == -1)
+	continue;
+      if ((fd = faccessat(sysfds[i], name, X_OK, 0)) != -1)
+	{
+	  fprintf(stderr, "\r\nSystem command: %s arg: %s\r\n", name, arg);
+	  return fd;
+	}
+    }
+  return -1;
 }
 
 static char *skip_comment(char *buf)
@@ -77,7 +111,8 @@ void ccmd(char *cmdline)
   char *cmd = skip_ws(skip_comment(cmdline));
   char *arg = skip_ws(skip_prgm(cmd));
   if (!builtin(cmd, arg))
-    fprintf (stderr, "\r\nSystem command: %s arg: %s\r\n", cmd, arg);
+    if (syscommand(cmd, arg) == -1)
+      fprintf (stderr, "\r\n%s - Unknown command\r\n", cmd);
 }
 
 void list_builtins(char *arg)

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -4,9 +4,9 @@
 #include <sys/utsname.h>
 #include "ccmd.h"
 
-void help(void);
-void list_builtins(void);
-void version(void);
+void help(char *);
+void version(char *);
+void list_builtins(char *);
 
 #define VERSION "0"
 
@@ -29,12 +29,12 @@ struct builtin builtins[] =
    {0, 0, 0, 0}
   };
 
-static int builtin(char *name)
+static int builtin(char *name, char *arg)
 {
   for (struct builtin *p = builtins; p->name; p++)
     if (strncmp(p->name, name, 6) == 0)
       {
-	p->fn();
+	p->fn(arg);
 	return 1;
       }
   return 0;
@@ -76,11 +76,11 @@ void ccmd(char *cmdline)
 {
   char *cmd = skip_ws(skip_comment(cmdline));
   char *arg = skip_ws(skip_prgm(cmd));
-  if (!builtin(cmd))
+  if (!builtin(cmd, arg))
     fprintf (stderr, "\r\nSystem command: %s arg: %s\r\n", cmd, arg);
 }
 
-void list_builtins(void)
+void list_builtins(char *arg)
 {
   fputs("\r\n<The commands explicitly listed here are part of DDT, not separate programs>\r\n", stderr);
   for (struct builtin *p = builtins; p->name; p++)
@@ -90,12 +90,12 @@ void list_builtins(void)
 	  "<prgm>", "<optional jcl>", "invoke program, passing JCL if present");
 }
 
-void help(void)
+void help(char *arg)
 {
   fputs(helptext, stderr);
 }
 
-void version(void)
+void version(char *arg)
 {
   struct utsname luname = { 0 };
   char ttyname[32];
@@ -112,7 +112,7 @@ void version(void)
     fprintf(stderr, "%s\r\n", ttyname);
 }
 
-void clear(void)
+void clear(char *arg)
 {
   fprintf(stderr, "\033[2J\033[H");
 }

--- a/src/ccmd.h
+++ b/src/ccmd.h
@@ -2,10 +2,8 @@ struct builtin {
   char *name;
   char *arghelp;
   char *desc;
-  void (*fn) (void);
+  void (*fn) (char *arg);
 };
 
 void ccmd(char *cmdline);
-
-void version(void);
-void clear(void);
+void clear(char *);

--- a/src/ccmd.h
+++ b/src/ccmd.h
@@ -5,5 +5,7 @@ struct builtin {
   void (*fn) (char *arg);
 };
 
+void init_ccmd(void);
 void ccmd(char *cmdline);
 void clear(char *);
+

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -166,7 +166,7 @@ static void print_args (void)
 
 static void formfeed (void)
 {
-  clear();
+  clear(NULL);
   fputs (prefix, stderr);
 }
 

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -201,6 +201,8 @@ void dispatch_init (void)
   alt[':'] = colon;
   alt['u'] = login;
   alt['?'] = print_args;
+
+  init_ccmd();
 }
 
 static void dispatch (int ch)


### PR DESCRIPTION
/bin, /sbin, /usr/bin, and /usr/sbin are internally mapped to SYS, SYS1, SYS2, and SYS3 as an array of o_path|o_directory file descriptors. Early use of *at() calls.

ccmd() now checks these directories if the specified colon command isn't builtin. No support for NFDIR or OFDIR.

Builtins now have access to the command line argument string.
