### PR TITLE
First set of job commands

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,5 +17,5 @@ main.o: main.c term.h dispatch.h
 dispatch.o: dispatch.c term.h ccmd.h jobs.h user.h
 term.o: term.c
 ccmd.o: ccmd.c ccmd.h jobs.h user.h
-jobs.o: jobs.c jobs.h
+jobs.o: jobs.c jobs.h user.h
 user.o: user.c user.h

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -37,6 +37,7 @@ struct builtin builtins[] =
    {"job", "", "create or select job [$j]", job},
    {"kill", "", "kill current job [$^x.]", kill_currjob},
    {"listj", "", "list jobs [$$v]", listj},
+   {"load", "<file>", "load file into core [$l]", load},
    {"login", "<name>", "log in [$u]", login_as},
    {"logout", "", "log off [$$u]", logout},
    {"massacre", "", "kill all your jobs", massacre},

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/utsname.h>
+#include <termios.h>
 #include "ccmd.h"
 #include "jobs.h"
 #include "user.h"
@@ -31,6 +32,9 @@ char helptext[] =
 struct builtin builtins[] =
   {
    {"clear", "", "clear screen [^L]", clear},
+   {"continue", "", "continue program, giving job TTY [$p]", contin},
+   {"go", "<start addr (opt)>", "start inferior [$g]", go},
+   {"gzp", "<start addr (opt)>", "start job without tty [$g^z^p]", gzp},
    {"help", "", "print out basic information", help},
    {"jcl", "<line>", "set job control string", jcl},
    {"jclprt", "", "print the job control strong", jclprt},
@@ -41,6 +45,9 @@ struct builtin builtins[] =
    {"login", "<name>", "log in [$u]", login_as},
    {"logout", "", "log off [$$u]", logout},
    {"massacre", "", "kill all your jobs", massacre},
+   {"proced", "", "same as proceed", proced},
+   {"proceed", "", "proceed job, leave tty to DDT [$p]", proced},
+   {"start", "<start addr (opt)>", "start inferior [<addr>$g]", go},
    {"version", "", "type version number of Linux and DDT", version},
    {"?", "", "list all : commands", list_builtins},
    {0, 0, 0, 0}

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <termios.h>
 #include <ctype.h>
 #include "term.h"
 #include "ccmd.h"
@@ -165,6 +166,12 @@ static void raid (void)
   done = 1;
 }
 
+static void start (void)
+{
+  go(prefix);
+  done = 1;
+}
+
 static void print_args (void)
 {
   fprintf (stderr, "\n\rArgs: %s\r\n", prefix);
@@ -225,6 +232,7 @@ void dispatch_init (void)
 
   plain[':'] = colon;
   alt[':'] = colon;
+  alt['g'] = start;
   alt['j'] = select_job;
   alt['u'] = login;
   alt['v'] = raid;

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "jobs.h"
+#include "user.h"
 
 #define MAXJOBS 8
 #define MAX_ARGS 256
@@ -219,4 +220,15 @@ void jcl(char *argstr)
 	 && ((currjob->proc.argv[argc] = strtok(NULL, " \t")) != NULL))
     currjob->proc.argv[++argc] == NULL;
   fputs("\r\n", stderr);
+}
+
+void load(char *name)
+{
+  if (!runame())
+    {
+      fprintf(stderr, "\r\n(Please Log In)\r\n\r\n:kill\r\n");
+      return;
+    }
+
+  fprintf(stderr, "\r\n load here\r\n");
 }

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -27,3 +27,4 @@ void next_job(void);
 void jcl(char *argstr);
 void jclprt(char *);
 void massacre(char *);
+void load(char *name);

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -13,8 +13,15 @@ struct job {
   char *jcl;
   char state;
   char slot;
+  struct termios tmode;
   struct process proc;
 };
+
+void jobs_init(void);
+int fgwait(void);
+void check_jobs(void);
+void list_currjob(void);
+void next_job(void);
 
 void job(char *jname);
 void listj(char *);
@@ -22,9 +29,13 @@ void show_currjob(char *arg);
 void kill_currjob(char *);
 
 void set_currjname(char *jname);
-void list_currjob(void);
-void next_job(void);
 void jcl(char *argstr);
 void jclprt(char *);
 void massacre(char *);
 void load(char *name);
+void go(char *addr);
+void gzp(char *addr);
+void contin(char *);
+void proced(char *);
+
+extern struct termios def_termios;

--- a/src/main.c
+++ b/src/main.c
@@ -9,8 +9,8 @@ static void cleanup (void)
 
 int main (int argc, char **argv)
 {
-  atexit (cleanup);
   term_init ();
+  atexit (cleanup);
   dispatch_init ();
 
   for (;;)

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include "term.h"
 #include "dispatch.h"
+#include "jobs.h"
 
 static void cleanup (void)
 {
@@ -11,10 +12,15 @@ int main (int argc, char **argv)
 {
   term_init ();
   atexit (cleanup);
+  jobs_init ();
   dispatch_init ();
 
   for (;;)
-    prompt_and_execute ();
+    if (!fgwait())
+      {
+	check_jobs();
+	prompt_and_execute ();
+      }
 
   return 0;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -5,12 +5,12 @@
 #include <sys/types.h>
 #include <signal.h>
 
-static struct termios old_termios;
+struct termios def_termios;
 static struct termios new_termios;
 
 void term_restore (void)
 {
-  tcsetattr (0, TCSANOW, &old_termios);
+  tcsetattr (0, TCSADRAIN, &def_termios);
 }
 
 void term_raw (void)
@@ -47,9 +47,9 @@ void term_init (void)
     }
   tcsetpgrp(0, pgid);
 
-  tcgetattr (0, &old_termios);
+  tcgetattr (0, &def_termios);
 
-  new_termios = old_termios;
+  new_termios = def_termios;
   cfmakeraw (&new_termios);
   term_raw ();
 }

--- a/src/term.c
+++ b/src/term.c
@@ -2,24 +2,56 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <termios.h>
+#include <sys/types.h>
+#include <signal.h>
 
 static struct termios old_termios;
+static struct termios new_termios;
+
+void term_restore (void)
+{
+  tcsetattr (0, TCSANOW, &old_termios);
+}
+
+void term_raw (void)
+{
+  tcsetattr (0, TCSANOW, &new_termios);
+}
 
 void term_init (void)
 {
-  struct termios new_termios;
+
+  if (!isatty(0))
+    {
+      fprintf(stderr, "ddt currently needs interactive tty\r\n");
+      exit(1);
+    }
+
+  pid_t pgid = 0;
+
+  while (tcgetpgrp(0) != (pgid = getpgrp()))
+    kill (-pgid, SIGTTIN);
+
+  signal(SIGINT, SIG_IGN);
+  signal(SIGQUIT, SIG_IGN);
+  signal(SIGTSTP, SIG_IGN);
+  signal(SIGTTIN, SIG_IGN);
+  signal(SIGTTOU, SIG_IGN);
+  signal(SIGCHLD, SIG_IGN);
+
+  pgid = getpid();
+  if (setpgid(pgid, pgid) < 0)
+    {
+      perror("term_init setpgid");
+      exit(1);
+    }
+  tcsetpgrp(0, pgid);
 
   tcgetattr (0, &old_termios);
 
   new_termios = old_termios;
   cfmakeraw (&new_termios);
-  tcsetattr (0, TCSANOW, &new_termios);
-}
-
-void term_restore (void)
-{
-  tcsetattr (0, TCSANOW, &old_termios);
-
+  term_raw ();
 }
 
 int term_read (void)

--- a/src/term.h
+++ b/src/term.h
@@ -1,3 +1,4 @@
 void term_init (void);
 void term_restore (void);
+void term_raw (void);
 int term_read (void);

--- a/src/user.c
+++ b/src/user.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <termios.h>
 #include "jobs.h"
 
 char *_runame = 0;
@@ -10,6 +11,7 @@ char *_msname = 0;
 
 void logout (char *ignore)
 {
+  fputs("\r\n", stderr);
   if (_runame)
     {
       massacre(NULL);

--- a/src/user.c
+++ b/src/user.c
@@ -3,15 +3,23 @@
 #include <stdio.h>
 #include "jobs.h"
 
-char *username = 0;
+char *_runame = 0;
+char *_xuname = 0;
+char *_hsname = 0;
+char *_msname = 0;
 
 void logout (char *ignore)
 {
-  if (username)
+  if (_runame)
     {
       massacre(NULL);
-      free(username);
-      username = 0;
+      free(_runame);
+      _runame = 0;
+      if (_xuname)
+	{
+	  free(_xuname);
+	  _xuname = 0;
+	}
     }
   else
     {
@@ -22,15 +30,14 @@ void logout (char *ignore)
 
 void login_as (char *name)
 {
-  if (username)
-    {
-      logout(NULL);
-    }
-  username = strdup(name);
-  fprintf (stderr, "\r\nWelcome, %s\r\n", username);
+  if (_runame)
+    logout(NULL);
+  _runame = strdup(name);
+  _xuname = strdup(name);
+  fprintf (stderr, "\r\nWelcome, %s\r\n", _xuname);
 }
 
-char *login_name(void)
+char *runame(void)
 {
-  return username;
+  return _runame;
 }

--- a/src/user.h
+++ b/src/user.h
@@ -1,3 +1,3 @@
 void logout (char *);
 void login_as (char *name);
-char *login_name(void);
+char *runame(void);


### PR DESCRIPTION
Added :load, :go, :gzp, :start, :continue, :proceed, :proced, and some of the associated dispatcher bindings.

It's still missing important pieces: ^z, :genjob, :new, :retry, integration with ccmd(), ..., but the following should work:

  :login rms
  :job foo
  :jcl 5
  :load /bin/sleep
  :go 
  :logout
  :logout

Loading requiring login.