### PR TITLE
Filenames, directories, and such.

### DIFF
--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -54,6 +54,7 @@ struct builtin builtins[] =
    {"monmode", "", "enter MONIT mode", set_monmode},
    {"new", "<prgm> <opt jcl>", "invoke <prgm>. If already using <pgrm>, make a second copy", new},
    {"nfdir", "<dir1>,<dir2>...", "add file directories to search list", nfdir},
+   {"ofdir", "<dir1>,<dir2>...", "remove file directories from search list", ofdir},
    {"proced", "", "same as proceed", proced},
    {"proceed", "", "proceed job, leave tty to DDT [$p]", proced},
    {"retry", "<prgm> <opt jcl>", "invoke <prgm>, clobbering any old copy", retry},

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -33,6 +33,7 @@ struct builtin builtins[] =
    {"clear", "", "clear screen [^L]", clear},
    {"chuname", "<new uname>", "change user name (log out and in again)", chuname},
    {"continue", "", "continue program, giving job TTY [$p]", contin},
+   {"cwd", "<dir>", "change working directory [$$^s]", cwd},
    {"ddtmode", "", "leave MONIT mode", set_ddtmode},
    {"delete", "<file>", "delete file [^o]", delete_file},
    {"forget", "", "hide a job from DDT wihout killing it", forget},

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -53,6 +53,7 @@ struct builtin builtins[] =
    {"massacre", "", "kill all your jobs", massacre},
    {"monmode", "", "enter MONIT mode", set_monmode},
    {"new", "<prgm> <opt jcl>", "invoke <prgm>. If already using <pgrm>, make a second copy", new},
+   {"nfdir", "<dir1>,<dir2>...", "add file directories to search list", nfdir},
    {"proced", "", "same as proceed", proced},
    {"proceed", "", "proceed job, leave tty to DDT [$p]", proced},
    {"retry", "<prgm> <opt jcl>", "invoke <prgm>, clobbering any old copy", retry},

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -250,6 +250,17 @@ static void stop (void)
   done = 1;
 }
 
+void asuser (void)
+{
+  if (altmodes > 1)
+    {
+      cwd(prefix);
+    }
+  else
+    fprintf(stderr, "\r\nWould cause next command to run as user: %s\r\n", prefix);
+  done = 1;
+}
+
 void backspace (void)
 {
   if (altmodes)
@@ -360,6 +371,7 @@ void dispatch_init (void)
   plain[CTRL_('N')] = step;
   plain[CTRL_('P')] = proceed;
   plain[CTRL_('Q')] = quotech;
+  alt[CTRL_('S')] = asuser;
   plain[CTRL_('X')] = stop;
   alt[CTRL_('X')] = stop;
   plain[ALTMODE] = altmode;

--- a/src/files.c
+++ b/src/files.c
@@ -229,6 +229,31 @@ void cwd(char *arg)
     errout(parsed.name);
 }
 
+static int equivdirs(struct file *a, struct file *b)
+{
+  return (strcmp(a->name, b->name) == 0
+	  && a->dirfd == b->dirfd
+	  && a->devfd == b->devfd);
+}
+
+static void delete_fdir(struct file *fdir)
+{
+  int i;
+  for (i = 0; i < QTY_FDIRS; i++)
+    {
+      if (equivdirs(fdir, finddirs[i]))
+	break;
+    }
+  if (i == QTY_FDIRS)
+    return;
+
+  for (i++; i < QTY_FDIRS; i++)
+    {
+      finddirs[i-1] = finddirs[i];
+    }
+  finddirs[i-1] = 0;
+}
+
 static void insert_fdir(struct file *fdir)
 {
   struct file *ins = NULL;
@@ -239,11 +264,14 @@ static void insert_fdir(struct file *fdir)
       t = finddirs[i];
       finddirs[i] = ins;
       if (t == 0) break;
-      if (strcmp(t->name, fdir->name) == 0
-	  && t->dirfd == fdir->dirfd
-	  && t->devfd == fdir->devfd)
+      if (equivdirs(t, fdir))
 	break;
     }
+}
+
+void ofdir(char *arg)
+{
+  fprintf(stderr, "\r\nWould ofdir here\r\n");
 }
 
 void nfdir(char *arg)

--- a/src/files.c
+++ b/src/files.c
@@ -101,6 +101,8 @@ struct file *findprog(char *name)
       if ((fd = faccessat(sysdirs[i].fd, name, X_OK, 0)) != -1)
 	return &(sysdirs[i]);
     }
+  if ((fd = faccessat(msname.fd, name, X_OK, 0)) != -1)
+    return &msname;
   return 0;
 }
 

--- a/src/files.c
+++ b/src/files.c
@@ -269,11 +269,6 @@ static void insert_fdir(struct file *fdir)
     }
 }
 
-void ofdir(char *arg)
-{
-  fprintf(stderr, "\r\nWould ofdir here\r\n");
-}
-
 static void parse_fnames(struct file *parsed[], int n, char *arg)
 {
   char *p;
@@ -307,6 +302,19 @@ static void parse_fnames(struct file *parsed[], int n, char *arg)
   }
   if (*p)
     fprintf(stderr, " ign args >%d? ", n);
+}
+
+void ofdir(char *arg)
+{
+  struct file *parsed[QTY_FDIRS] = { 0 };
+
+  fputs("\r\n", stderr);
+
+  parse_fnames(parsed, QTY_FDIRS, arg);
+
+  for (int i = 0; i < QTY_FDIRS; i++)
+    if (parsed[i] != NULL)
+      delete_fdir(parsed[i]);
 }
 
 void nfdir(char *arg)

--- a/src/files.c
+++ b/src/files.c
@@ -64,7 +64,7 @@ void files_init(void)
     }
 
   hsname.name = strdup(msname.name);
-  hsname.devfd = msname.devfd;
+  hsname.devfd = dsk.fd;
   hsname.dirfd = msname.dirfd;
   errno = 0;
   hsname.fd = openat(dsk.fd, hsname.name,
@@ -87,14 +87,6 @@ struct file *findprog(char *name)
 	return &(sysdirs[i]);
     }
   return 0;
-}
-
-void delete_file(char *name)
-{
-  fputs("\r\n", stderr);
-  errno = 0;
-  if (unlinkat(msname.fd, name, 0) == -1)
-    errout(0);
 }
 
 static inline char *skip_ws(char *buf)
@@ -156,9 +148,27 @@ char *parse_fname(struct file *f, char *str)
   return str + strlen(str);
 }
 
+void delete_file(char *name)
+{
+  struct file parsed = { 0, dsk.fd, msname.fd, -1 };
+  char *p = parse_fname(&parsed, name);
+  fputs("\r\n", stderr);
+  if (p == NULL)
+    return;
+  if (parsed.name == NULL)
+    {
+      fprintf(stderr, " no defaulting yet\r\n");
+      return;
+    }
+  errno = 0;
+  if (unlinkat(parsed.dirfd, parsed.name, 0) == -1)
+    errout(0);
+  free(parsed.name);
+}
+
 void cwd(char *arg)
 {
-  struct file parsed = { 0, -1, -1, -1 };
+  struct file parsed = { 0, dsk.fd, -1, -1 };
 
   fputs("\r\n", stderr);
 

--- a/src/files.c
+++ b/src/files.c
@@ -105,6 +105,16 @@ struct file *findprog(char *name)
       if ((fd = faccessat(sysdirs[i].fd, name, X_OK, 0)) != -1)
 	return &(sysdirs[i]);
     }
+  for (int i = 0; i < QTY_FDIRS; i++)
+    {
+      if (finddirs[i] == NULL)
+	break;
+      fprintf(stderr, " %s;\r\n", finddirs[i]->name);
+      if ((fd = faccessat(finddirs[i]->fd, name, X_OK, 0)) != -1)
+	{
+	  return finddirs[i];
+	}
+    }
   if ((fd = faccessat(msname.fd, name, X_OK, 0)) != -1)
     return &msname;
   return 0;

--- a/src/files.h
+++ b/src/files.h
@@ -12,6 +12,10 @@ void cwd(char *arg);
 void nfdir(char *arg);
 void ofdir(char *arg);
 
-extern struct file dsk;
+void typeout_fname(struct file *f);
+
+extern struct file devices[];
 extern struct file hsname;
 extern struct file msname;
+
+#define DEVDSK 0

--- a/src/files.h
+++ b/src/files.h
@@ -10,6 +10,7 @@ struct file *findprog(char *name);
 void delete_file(char *name);
 void cwd(char *arg);
 void nfdir(char *arg);
+void ofdir(char *arg);
 
 extern struct file dsk;
 extern struct file hsname;

--- a/src/files.h
+++ b/src/files.h
@@ -8,6 +8,7 @@ struct file {
 void files_init(void);
 struct file *findprog(char *name);
 void delete_file(char *name);
+void cwd(char *arg);
 
 extern struct file dsk;
 extern struct file hsname;

--- a/src/files.h
+++ b/src/files.h
@@ -9,6 +9,7 @@ void files_init(void);
 struct file *findprog(char *name);
 void delete_file(char *name);
 void cwd(char *arg);
+void nfdir(char *arg);
 
 extern struct file dsk;
 extern struct file hsname;

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -490,7 +490,7 @@ void load_prog(char *name)
 	errout("child openat");
 	return;
       }
-  currjob->proc.ufname.devfd = dsk.fd;
+  currjob->proc.ufname.devfd = devices[DEVDSK].fd;
   currjob->proc.ufname.dirfd = msname.fd;
   currjob->proc.ufname.fd = fd;
 
@@ -691,13 +691,14 @@ void lfile(char *unused)
       fputs(" job? ", stderr);
       return;
     }
+  fputs("\r\n", stderr);
   if (currjob->state == '-')
     {
-      fputs("\r\n not loaded? \r\n", stderr);
+      fputs(" not loaded? \r\n", stderr);
       return;
     }
-  fprintf(stderr, "\r\n%d: %d; %s (%d)\r\n",
-	  currjob->proc.ufname.devfd, currjob->proc.ufname.dirfd, currjob->proc.ufname.name, currjob->proc.ufname.fd);
+  typeout_fname(&(currjob->proc.ufname));
+  fputs("\r\n", stderr);
 }
 
 void forget(char *unused)


### PR DESCRIPTION
Several improvements to filename handing.

FIlenames are parsed.
    dsk: is the only device currently.
    Directories are parsed, but currently throw an error.
    A single-word filename is parsed. Absolute pathnames work.

Filename components can occur in any order. With or without extra spacing.
  e.g. `dsk: dir; fname` is equivalent to `fname dir;dsk:` or `dsk:fname dir;`
Note that the `fname` portion requires a space, comma, or end of string as terminator.

Added :nfdir and :ofdir. Searching for programs searches these extra directories now. Eight slots are provided. The directory name is typed out when used in a program search.

Added :cwd, $$^s, and the start of hsname.

The default filename mechanism has been added.
:delete now uses and sets this default.
