### PR TITLE
Initial support for symbols

### DIFF
--- a/src/aeval.c
+++ b/src/aeval.c
@@ -5,8 +5,6 @@
 #include <errno.h>
 #include "aeval.h"
 
-// TODO: jobs.h needs to include termios.h
-#include <termios.h>
 // TODO: errout needs to be moved out of jobs.c
 #include "jobs.h"
 

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -116,16 +116,16 @@ static char *skip_prgm(char *buf)
   return buf;
 }
 
-void ccmd(char *cmdline)
+void ccmd(char *cmdline, int altmodes)
 {
   char *cmd = skip_ws(skip_comment(cmdline));
   char *arg = skip_ws(skip_prgm(cmd));
-  if (!builtin(cmd, arg))
+  if (altmodes || !builtin(cmd, arg))
     {
       if (!runame())
 	fputs("\r\n(Please Log In)\r\n\r\n:kill\r\n", stderr);
       else
-	run_(cmd, arg, genjfl);
+	run_(cmd, arg, genjfl, altmodes);
     }
 }
 
@@ -161,11 +161,11 @@ void set_ddtmode(char *unused)
 static void retry(char *arg)
 {
   char *jcl = skip_ws(skip_prgm(arg));
-  run_(arg, jcl, 0);
+  run_(arg, jcl, 0, 0);
 }
 
 static void new(char *arg)
 {
   char *jcl = skip_ws(skip_prgm(arg));
-  run_(arg, jcl, 1);
+  run_(arg, jcl, 1, 0);
 }

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -51,6 +51,7 @@ struct builtin builtins[] =
    {"job", "", "create or select job [$j]", select_job},
    {"kill", "", "kill current job [$^x.]", kill_currjob},
    {"lfile", "", "print filename of last file loaded", lfile},
+   {"listp", "", "list block struct of the job's symbol table", listp},
    {"listf", "<dir>", "list files [^f]", listf},
    {"listj", "", "list jobs [$$v]", listj},
    {"load", "<file>", "load file into core [$l]", load_prog},

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
-#include <termios.h>
 #include "ccmd.h"
 #include "jobs.h"
 #include "user.h"

--- a/src/ccmd.h
+++ b/src/ccmd.h
@@ -1,5 +1,5 @@
 void init_ccmd(void);
-void ccmd(char *cmdline);
+void ccmd(char *cmdline, int altmodes);
 void set_ddtmode(char *);
 void set_monmode(char *);
 

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -2,7 +2,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <stdio.h>
-#include <termios.h>
 #include <sys/ptrace.h>
 #include <sys/reg.h>
 #include "jobs.h"

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -178,7 +178,7 @@ static void colon (void)
     {
       char *cmdline = suffix();
       if (cmdline != NULL)
-	ccmd(cmdline);
+	ccmd(cmdline, altmodes);
       else			/* user rubbed out : */
 	{
 	  fprintf (stderr, "\010 \010");
@@ -351,7 +351,7 @@ void load (void)
 void kreat (void)
 {
   if (nprefix)
-    run_(prefix, NULL, 0);
+    run_(prefix, NULL, 0, altmodes);
   else
     fputs("?? ", stderr);
   done = 1;
@@ -531,7 +531,7 @@ void prompt_and_execute (void)
       char *cmdline = suffix();
       if (cmdline != NULL)
 	{
-	  ccmd(cmdline);
+	  ccmd(cmdline, 0);
 	  return;
 	}
       else

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -352,6 +352,8 @@ void kreat (void)
 {
   if (nprefix)
     run_(prefix, NULL, 0, altmodes);
+  else if (altmodes == 1)
+    load_symbols(currjob);
   else
     fputs("?? ", stderr);
   done = 1;
@@ -469,6 +471,7 @@ void dispatch_init (void)
   plain[CTRL_('F')] = files;
   plain[BACKSPACE] = backspace;
   plain[CTRL_('K')] = kreat;
+  alt[CTRL_('K')] = kreat;
   plain[FORMFEED] = formfeed;
   alt[FORMFEED] = formfeed;
   plain[CTRL_('N')] = step;

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <termios.h>
 #include <ctype.h>
 #include "term.h"
 #include "ccmd.h"

--- a/src/files.c
+++ b/src/files.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <termios.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <time.h>

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <sys/ptrace.h>
 #include <errno.h>
-#include <termios.h>
 #include <ctype.h>
 #include "jobs.h"
 #include "user.h"

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -6,6 +6,8 @@ struct process {
   struct file ufname;
   char **argv;
   char **env;
+  void *syms;
+  size_t symlen;
   pid_t pid;
   int status;
 };
@@ -44,7 +46,7 @@ void proced(char *);
 void lfile(char *);
 void forget(char *);
 void self(char *);
-void run_(char *jname, char *arg, int genj);
+void run_(char *jname, char *arg, int genj, int loadsyms);
 void genjob(char *);
 
 void errout(char *arg);

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -47,6 +47,7 @@ void lfile(char *);
 void forget(char *);
 void self(char *);
 void genjob(char *);
+void listp(char *);
 
 void run_(char *jname, char *arg, int genj, int loadsyms);
 void load_symbols(struct job *j);

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -1,3 +1,4 @@
+#include <termios.h>
 #include "files.h"
 
 struct process {

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -46,8 +46,10 @@ void proced(char *);
 void lfile(char *);
 void forget(char *);
 void self(char *);
-void run_(char *jname, char *arg, int genj, int loadsyms);
 void genjob(char *);
+
+void run_(char *jname, char *arg, int genj, int loadsyms);
+void load_symbols(struct job *j);
 
 void errout(char *arg);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <termios.h>
 #include "term.h"
 #include "dispatch.h"
 #include "jobs.h"


### PR DESCRIPTION
Adding symbol loading.
It does an mmap() of the elf executable. The associated ram pointer and length are stored in the job's process structure.

$:foo works like :foo, with the addition of symbol loading.
$^k load symbols for an existing loaded job.
I haven't done anything with $l yet.

:listp lists the section names in the elf file.
