### PR TITLE
Typeout

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,5 +37,5 @@ ccmd.o: ccmd.c ccmd.h $(INCL) user.h term.h debugger.h
 jobs.o: jobs.c $(INCL) user.h term.h debugger.h
 user.o: user.c $(INCL) term.h
 files.o: files.c $(INCL) term.h
-debugger.o: debugger.c $(INCL)
+debugger.o: debugger.c $(INCL) debugger.h
 aeval.o: aeval.c aeval.h jobs.h

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -269,10 +269,10 @@ void tmch(uint64_t value)
   outchar(c);
 }
 
-char radix = 16;
+static char radix = 16;
 static char radixchars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
-void tmc(uint64_t value)
+static void outradix(uint64_t value)
 {
   int i = 64;
   char str[65];
@@ -286,6 +286,11 @@ void tmc(uint64_t value)
   fputs(&str[i], stderr);
 }
 
+void tmc(uint64_t value)
+{
+  outradix(value);
+}
+
 void tmf(uint64_t value)
 {
   fprintf(stderr, "%f", (double)value);
@@ -293,7 +298,9 @@ void tmf(uint64_t value)
 
 void tmh(uint64_t value)
 {
-  fprintf(stderr, "%x,,%x", (uint32_t)(value >> 32), (uint32_t)(value & 0xffffffff));
+  outradix(value >> 32);
+  fputs(",,", stderr);
+  outradix(value & 0xffffffff);
 }
 
 void typeout_pc(struct job *j)

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -32,21 +32,24 @@ along with Linux-ddt. If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <ctype.h>
 #include "jobs.h"
+#include "debugger.h"
+
+typeoutfunc *mperce = tmc;	/* tms */
+typeoutfunc *mamper = tmc;	/* tmsq */
+typeoutfunc *mdolla = tmc;	/* tms */
+typeoutfunc *mprime = tmc;	/* tm6 */
+typeoutfunc *mdquot = tma;
+typeoutfunc *mnmsgn = tmch;
+typeoutfunc *mch = tmc;
+typeoutfunc *sch = tmc;
 
 uint64_t qreg = 0;
 
 static void crlf(void)
 {
   fputs("\r\n", stderr);
-}
-
-void typeout_pc(struct job *j)
-{
-  long pc = ptrace(PTRACE_PEEKUSER, j->proc.pid, RIP * 8, NULL);
-  long data = ptrace(PTRACE_PEEKDATA, j->proc.pid, pc, NULL);
-
-  fprintf(stderr, "%lx)   %lx   ", pc, data);
 }
 
 void step_job(struct job *j)
@@ -229,4 +232,64 @@ void symlod(char *arg)
     unload_symbols(currjob);
 
   load_symbols(currjob);
+}
+
+static void outchar(unsigned char c)
+{
+  if (c & 0x80)
+    {
+      fputc('$', stderr);
+      c &= 0x7f;
+    }
+  if (c == 0x7f)
+    {
+      fputc('^', stderr);
+      c = '?';
+    }
+  else if (iscntrl(c))
+    {
+      fputc('^', stderr);
+      c += 64;
+    }
+  fputc(c, stderr);
+}
+
+void tma(uint64_t value)
+{
+  unsigned char *str = (char *)value;
+  for (int i = 0; str[i]; i++)
+    outchar(str[i]);
+}
+
+void tmch(uint64_t value)
+{
+  char c = (char)(value & 0x7f);
+
+  fputs("$1#", stderr);
+  outchar(c);
+}
+
+void tmc(uint64_t value)
+{
+  fprintf(stderr, "%lu", value);
+}
+
+void tmf(uint64_t value)
+{
+  fprintf(stderr, "%f", (double)value);
+}
+
+void tmh(uint64_t value)
+{
+  fprintf(stderr, "%x,,%x", (uint32_t)(value >> 32), (uint32_t)(value & 0xffffffff));
+}
+
+void typeout_pc(struct job *j)
+{
+  long pc = ptrace(PTRACE_PEEKUSER, j->proc.pid, RIP * 8, NULL);
+  long data = ptrace(PTRACE_PEEKDATA, j->proc.pid, pc, NULL);
+
+  fprintf(stderr, "%lx)   ", pc);
+  sch(data);
+  fputs("   ", stderr);
 }

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -270,7 +270,13 @@ void tmch(uint64_t value)
 }
 
 static char radix = 16;
+static char tradix = 16;
 static char radixchars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+void resetradix(void)
+{
+  tradix = radix;
+}
 
 static void outradix(uint64_t value)
 {
@@ -279,11 +285,18 @@ static void outradix(uint64_t value)
   str[i] = 0;
   for (i = 64; i--;)
     {
-      str[i] = radixchars[(value % radix)];
-      if (!(value /= radix))
+      str[i] = radixchars[(value % tradix)];
+      if (!(value /= tradix))
 	break;
     }
   fputs(&str[i], stderr);
+}
+
+void setradix(int r, int perm)
+{
+  tradix = (r % 36);
+  if (perm > 0)
+    radix = tradix;
 }
 
 void tmc(uint64_t value)

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -269,9 +269,21 @@ void tmch(uint64_t value)
   outchar(c);
 }
 
+char radix = 16;
+static char radixchars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
 void tmc(uint64_t value)
 {
-  fprintf(stderr, "%lu", value);
+  int i = 64;
+  char str[65];
+  str[i] = 0;
+  for (i = 64; i--;)
+    {
+      str[i] = radixchars[(value % radix)];
+      if (!(value /= radix))
+	break;
+    }
+  fputs(&str[i], stderr);
 }
 
 void tmf(uint64_t value)

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -37,6 +37,9 @@ void tma(uint64_t value);
 void tmch(uint64_t value);
 void tmf(uint64_t value);
 
+void resetradix(void);
+void setradix(int r, int perm);
+
 extern typeoutfunc *mdquot;
 extern typeoutfunc *mnmsgn;
 extern typeoutfunc *mdolla;

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -32,4 +32,17 @@ void listp(char *);
 void lists(char *);
 void symlod(char *arg);
 
+void tmc(uint64_t value);
+void tma(uint64_t value);
+void tmch(uint64_t value);
+void tmf(uint64_t value);
+
+extern typeoutfunc *mdquot;
+extern typeoutfunc *mnmsgn;
+extern typeoutfunc *mdolla;
+extern typeoutfunc *mperce;
+extern typeoutfunc *mamper;
+extern typeoutfunc *mprime;
+extern typeoutfunc *tch;
+
 extern uint64_t qreg;

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -101,6 +101,31 @@ static void altarg (void)
     fputc(BELL, stderr);
 }
 
+static void amper (void)
+{
+  if (!currjob)
+    {
+      fputs(" job? ", stderr);
+      return;
+    }
+
+  if (nprefix)
+    arg();
+  else
+    currjob->tamper(qreg);
+}
+
+static void nmsgn (void)
+{
+  if (nprefix)
+    arg();
+  else
+    if (currjob)
+      currjob->tnmsgn(qreg);
+    else
+      mnmsgn(qreg);
+}
+
 static void arg4 (void)
 {
   if (narg4 < PREFIX_MAXBUF)
@@ -413,7 +438,7 @@ void files (void)
   done = 1;
 }
 
-void showq (void)
+void equal (void)
 {
   if (nprefix)
     {
@@ -430,11 +455,11 @@ void showq (void)
     }
   if (altmodes)
     {
-      fprintf(stderr, "%f   ", (double)qreg);
+      tmf(qreg);
       altmodes = 0;
     }
   else
-    fprintf(stderr, "%lu   ", qreg);
+    tmc(qreg);
 
  leave:
   prefix[nprefix] = nprefix = 0;
@@ -537,11 +562,13 @@ void dispatch_init (void)
   alt['-'] = altarg;
   alt['.'] = altarg;
   alt['!'] = altarg;
+  plain['#'] = nmsgn;
+  plain['&'] = amper;
 
   plain[':'] = colon;
   alt[':'] = colon;
-  plain['='] = showq;
-  alt['='] = showq;
+  plain['='] = equal;
+  alt['='] = equal;
 
   alt['g'] = start;
   alt['j'] = job;

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -457,12 +457,49 @@ void equal (void)
     {
       tmf(qreg);
       altmodes = 0;
+      fn = plain;
     }
   else
     tmc(qreg);
 
  leave:
   prefix[nprefix] = nprefix = 0;
+}
+
+static void radix8 (void)
+{
+  altmodes--;
+  setradix(8, altmodes);
+  if (altmodes)
+    {
+      fputs("   ", stderr);
+      altmodes = 0;
+    }
+  fn = plain;
+}
+
+static void radix10 (void)
+{
+  altmodes--;
+  setradix(10, altmodes - 1);
+  if (altmodes)
+    {
+      fputs("   ", stderr);
+      altmodes = 0;
+    }
+  fn = plain;
+}
+
+static void radix16 (void)
+{
+  altmodes--;
+  setradix(16, altmodes - 1);
+  if (altmodes)
+    {
+      fputs("   ", stderr);
+      altmodes = 0;
+    }
+  fn = plain;
 }
 
 static void chquote (void)
@@ -570,12 +607,15 @@ void dispatch_init (void)
   plain['='] = equal;
   alt['='] = equal;
 
+  alt['d'] = radix10;
   alt['g'] = start;
   alt['j'] = job;
   alt['l'] = load;
+  alt['o'] = radix8;
   alt['p'] = cont;
   alt['u'] = login;
   alt['v'] = raid;
+  alt['X'] = radix16;
   alt['?'] = print_args;
 
   monmode = 0;
@@ -608,6 +648,7 @@ void prompt_and_execute (void)
   prefix[0] = nprefix = 0;
   arg4str[0] = narg4 = 0;
   fn = plain;
+  resetradix();
 
   do
     {

--- a/src/jobs.c
+++ b/src/jobs.c
@@ -189,6 +189,12 @@ static struct job *initslot(char slot, char *jname)
   j->proc.symlen = 0;
   j->proc.pid = 0;
   j->proc.status = 0;
+  j->tperce = mperce;
+  j->tamper = mamper;
+  j->tdollar = mdolla;
+  j->tdquote = mdquot;
+  j->tprime = mprime;
+  j->tnmsgn = mnmsgn;
 
   return j;
 }

--- a/src/jobs.h
+++ b/src/jobs.h
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Linux-ddt. If not, see <https://www.gnu.org/licenses/>.
 */
+#include <stdint.h>
 #include <termios.h>
 #include "files.h"
 
@@ -30,6 +31,8 @@ struct process {
   int status;
 };
 
+typedef void (typeoutfunc)(uint64_t);
+
 struct job {
   char *jname;
   char *xjname;
@@ -38,6 +41,12 @@ struct job {
   char slot;
   struct termios tmode;
   struct process proc;
+  typeoutfunc *tdquote;
+  typeoutfunc *tnmsgn;
+  typeoutfunc *tdollar;
+  typeoutfunc *tperce;
+  typeoutfunc *tamper;
+  typeoutfunc *tprime;
 };
 
 void jobs_init(void);


### PR DESCRIPTION
Initial support for typeout modes.
Added #, &, $d, $$d, $o, $$o
Also added 'non-standard' $X and $$X to select hex output, temporarily or permanently.
